### PR TITLE
updated AWS CDK API for VPC and StateMachine constructs

### DIFF
--- a/lib/stepfunctions-stack.ts
+++ b/lib/stepfunctions-stack.ts
@@ -170,7 +170,7 @@ export class StepFunctionsStack extends Stack {
         const definition = sfn.Chain.start(parallel).next(vacuumAnalyze).next(successNotification).next(succeed);
 
         this.stateMachine = new sfn.StateMachine(this, 'ServerlessRSQLETLFramework', {
-            definition,
+            definitionBody: sfn.DefinitionBody.fromChainable(definition),
             timeout: Duration.hours(2),
             role: this.stepFunctionsRole,
         });

--- a/lib/vpc-stack.ts
+++ b/lib/vpc-stack.ts
@@ -9,7 +9,7 @@ export class VpcStack extends Stack {
         super(scope, id, props);
 
         this.vpc = new ec2.Vpc(this, 'RedshiftVPC', {
-            cidr: '10.0.0.0/16',
+            ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
             maxAzs: 3,
             subnetConfiguration: [
                 {


### PR DESCRIPTION
*Description of changes:*

Updated AWS CDK API for VPC and StateMachine constructs:

* updated deprecated VPC cidr property to use ipAddresses
* updated deprecated StateMachine definition property to use definitionBody